### PR TITLE
Amended Transform to Pass Failing Tests

### DIFF
--- a/pipeline/test_transform.py
+++ b/pipeline/test_transform.py
@@ -38,8 +38,8 @@ def test_format_authors_removes_extras():
 
 def test_format_authors_only_names():
     """Tests that author list is returned when columns does not start 'By ' """
-    result = format_authors("Velma and Daphne")
-    assert result == ["Velma", "Daphne"]
+    result = format_authors("Velma and Daphne & Fred")
+    assert result == ["Velma", "Daphne", "Fred"]
 
 
 def test_format_scraped_articles_strips_URL(mock_scraped_df):

--- a/pipeline/transform.py
+++ b/pipeline/transform.py
@@ -53,13 +53,14 @@ def format_authors(authors: str) -> str | None :
         return None
 
     if authors[:3].lower() == "by ":
-        authors = authors.lower().replace("by ", "").replace(" &", ",")
-        authors = authors.replace(" and", ",")
-        authors = authors.split(", ")
+        authors = authors.lower().replace("by ", "", 1)
+    authors = authors.replace(" &", ",")
+    authors = authors.replace(" and", ",")
+    authors = authors.split(", ")
 
-        authors = list(map(lambda author: author.title(), authors))
-
-        return authors
+    authors = list(map(lambda author: author.title(), authors))
+    
+    return authors
 
 
 def format_scraped_articles_df(scraped_articles_df: DataFrame) -> DataFrame:


### PR DESCRIPTION
Changed the format_authors function to pass the two failing tests:
- if author list doesn't start with 'By '
- if an author name has 'by ' in it